### PR TITLE
fix rspec deprecated warning

### DIFF
--- a/spec/backlog_kit/client_spec.rb
+++ b/spec/backlog_kit/client_spec.rb
@@ -280,8 +280,7 @@ describe BacklogKit::Client do
         allow_any_instance_of(Faraday::Connection).to receive(:send).and_raise(Faraday::ConnectionFailed, message)
       end
 
-      subject { -> { response } }
-      it { is_expected.to raise_error(BacklogKit::Error, "ConnectionError - #{message}") }
+      it { expect { subject }.to raise_error(BacklogKit::Error, "ConnectionError - #{message}") }
     end
   end
 

--- a/spec/backlog_kit/response/raise_error_spec.rb
+++ b/spec/backlog_kit/response/raise_error_spec.rb
@@ -20,7 +20,7 @@ describe BacklogKit::Response::RaiseError do
   end
 
   describe '#on_complete' do
-    subject { -> { response.on_complete(faraday_env_mock) } }
+    subject { response.on_complete(faraday_env_mock) }
 
     context 'when error code contains 1' do
       let(:error_code) { 1 }
@@ -79,27 +79,27 @@ describe BacklogKit::Response::RaiseError do
 
     context 'when error code contains unexpected code' do
       let(:error_code) { 99 }
-      it { is_expected.to raise_error(BacklogKit::Error, "[ERROR 1] UnexpectedError - エラー1 (CODE: #{error_code}), [ERROR 2] UnexpectedError - エラー2 (CODE: #{error_code})") }
+      it { expect { subject }.to raise_error(BacklogKit::Error, "[ERROR 1] UnexpectedError - エラー1 (CODE: #{error_code}), [ERROR 2] UnexpectedError - エラー2 (CODE: #{error_code})") }
     end
 
     context 'when status code is 204' do
       let(:faraday_env_status) { 204 }
-      it { is_expected.not_to raise_error }
+      it { expect { subject }.not_to raise_error }
     end
 
     context 'when content type is not json' do
       let(:faraday_env_headers) { { 'content-type' => 'image/gif' } }
-      it { is_expected.not_to raise_error }
+      it { expect { subject }.not_to raise_error }
     end
 
     context 'when json body is array' do
       let(:faraday_env_body) { [{ 'key1' => 'value1' }].to_json }
-      it { is_expected.not_to raise_error }
+      it { expect { subject }.not_to raise_error }
     end
 
     context 'when json body does not contains error' do
       let(:faraday_env_body) { { 'key1' => 'value1' }.to_json }
-      it { is_expected.not_to raise_error }
+      it { expect { subject }.not_to raise_error }
     end
   end
 

--- a/spec/support/shared_examples_for.rb
+++ b/spec/support/shared_examples_for.rb
@@ -1095,8 +1095,8 @@ shared_examples_for 'a resource file' do
 end
 
 shared_examples_for 'a invalid request error' do
-  subject { -> { response.body } }
-  it { is_expected.to raise_error(BacklogKit::Error, "[ERROR 1] InvalidRequestError - error.unknownParameter : #{invalid_param_key} (CODE: 7)") }
+  subject { response.body }
+  it { expect { subject }.to raise_error(BacklogKit::Error, "[ERROR 1] InvalidRequestError - error.unknownParameter : #{invalid_param_key} (CODE: 7)") }
 end
 
 shared_examples_for 'raise errors' do
@@ -1104,6 +1104,6 @@ shared_examples_for 'raise errors' do
     BacklogKit::Response::RaiseError::CODE_ERRORS[error_code].name.demodulize
   end
 
-  subject { -> { response.on_complete(faraday_env_mock) } }
-  it { is_expected.to raise_error(BacklogKit::Error, "[ERROR 1] #{error_class_name} - エラー1 (CODE: #{error_code}), [ERROR 2] #{error_class_name} - エラー2 (CODE: #{error_code})") }
+  subject { response.on_complete(faraday_env_mock) }
+  it { expect { subject }.to raise_error(BacklogKit::Error, "[ERROR 1] #{error_class_name} - エラー1 (CODE: #{error_code}), [ERROR 2] #{error_class_name} - エラー2 (CODE: #{error_code})") }
 end


### PR DESCRIPTION
fix below deprecated warnings.
```
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise BacklogKit::Error with "ConnectionError - getaddrinfo: nodename nor servname provided, or not known"` not `expect(value).to raise BacklogKit::Error with "ConnectionError - getaddrinfo: nodename nor servname provided, or not known"`
```
